### PR TITLE
Example of struct conversion ignoring tags

### DIFF
--- a/examples/struct_conversion.go
+++ b/examples/struct_conversion.go
@@ -1,0 +1,11 @@
+func example() {
+	type T1 struct {
+		X int `json:"foo"`
+	}
+	type T2 struct {
+		X int `json:"bar"`
+	}
+	var v1 T1
+	var v2 T2
+	v1 = T1(v2) // now legal
+}

--- a/presentation.slide
+++ b/presentation.slide
@@ -54,7 +54,7 @@ The overhead of calls from Go into C has been reduced by about half.
 
 When explicitly converting a value from one struct type to another, as of Go 1.8 the tags are ignored.
 
-[[https://github.com/davecheney/go-1.8-release-party/issues/2][TODO NEEDS EXAMPLE]]
+.code examples/struct_conversion.go
 
 * Ports
 


### PR DESCRIPTION
Resolves davecheney/go-1.8-release-party#2

- Adds example of struct conversion ignoring tags in `go1.8`

