### PR TITLE
Vet documentation check for duplicate json struct tags and incorrect multi tag format

### DIFF
--- a/examples/vet_repeated_json_tags.go
+++ b/examples/vet_repeated_json_tags.go
@@ -1,0 +1,9 @@
+package main
+
+type T struct {
+	A string `json:"A"`
+	// vet error: struct field B repeats json tag "A" also at vet_repeated_tags.go:4
+	B string `json:"A"`
+	// vet error: not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
+	C string `json:"C"xml:"C"`
+}

--- a/presentation.slide
+++ b/presentation.slide
@@ -123,9 +123,9 @@ The new `go`bug` command starts a bug report on GitHub, prefilled with informati
 
 `go`fix` now rewrites references to `golang.org/x/net/context` to the standard library provided `context` package.
 
-* go vet
+* go vet - repeated struct tags and multiple struct tags
 
-[[https://github.com/davecheney/go-1.8-release-party/issues/6][TODO NEED DETAILS ON THE GO VET IMPROVEMENTS IN 1.8]]
+.code examples/vet_repeated_json_tags.go
 
 * Plugins
 


### PR DESCRIPTION
Closes davecheney/go-1.8-release-party#6